### PR TITLE
chore: configure .gitattributes for line endings, linguist and merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# ================================
+# 1. Normalize line endings
+# ================================
+* text=auto eol=lf
+
+*.sh text eol=lf
+
+*.php text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.vue text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# ================================
+# 2. Linguist override (GitHub)
+# ================================
+
+/composer.lock linguist-generated
+/package-lock.json linguist-generated
+/yarn.lock linguist-generated
+/vendor/** linguist-vendored
+/node_modules/** linguist-vendored
+/tools/** linguist-vendored
+
+# ================================
+# 3. Merge Strategy
+# ================================
+composer.lock merge=union
+package-lock.json merge=union
+yarn.lock merge=union
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
Normalize line endings to LF across code files and configure GitHub Linguist
to exclude dependency and tool directories from language stats.

Also sets merge strategies for lockfiles and binary assets.