### PR TITLE
refactor: reorganize UploadAbstraction structure and rename UploadInt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ composer require chrisdjst/upload-abstraction
 ## ✅ Usage Example
 
 ```php
-use UploadAbstraction\UploadFile;
-use UploadAbstraction\Enums\UploadDriver;
+use UploadAbstraction\UploaderFile;
+use UploadAbstraction\Enums\UploaderDriver;
 
-$upload = new UploadFile(UploadDriver::S3);
+$upload = new UploaderFile(UploaderDriver::S3);
 $upload->createRepository('my-bucket');
 $upload->upload('my-bucket', 'file.txt', '/tmp/file.txt');
 $files = $upload->listObjects('my-bucket');
@@ -93,7 +93,7 @@ services:
 
 ## 📚 Extendable Architecture
 
-You can add custom storage drivers by implementing the `UploadAbstraction\Contracts\UploadDriverInterface` interface. This allows seamless integration with other providers (e.g. Google Cloud Storage, Azure Blob Storage).
+You can add custom storage drivers by implementing the `UploadAbstraction\Contracts\UploaderDriverInterface` interface. This allows seamless integration with other providers (e.g. Google Cloud Storage, Azure Blob Storage).
 
 ## 📁 Project Structure
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "autoload": {
         "psr-4": {
-            "UploadAbstractor\\": "src/"
+            "UploadAbstractor\\": "src/UploadAbstractor/",
+            "EnvManager\\": "src/EnvManager/"
         }
     },
     "require-dev": {

--- a/src/EnvManager/Contracts/EnvironmentInterface.php
+++ b/src/EnvManager/Contracts/EnvironmentInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace UploadAbstractor\Support\Contracts;
+namespace EnvManager\Contracts;
 
 interface EnvironmentInterface
 {

--- a/src/EnvManager/EnvManager.php
+++ b/src/EnvManager/EnvManager.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace UploadAbstractor\Support;
+namespace EnvManager;
 
-use UploadAbstractor\Support\Contracts\EnvironmentInterface;
-use UploadAbstractor\Support\Loaders\DotenvLoader;
-use UploadAbstractor\Support\Readers\{ArrayEnvReader, ServerEnvReader, GetenvReader};
+use EnvManager\Contracts\EnvironmentInterface;
+use EnvManager\Loaders\DotenvLoader;
+use EnvManager\Readers\{ArrayEnvReader, ServerEnvReader, GetenvReader};
 
 class EnvManager
 {

--- a/src/EnvManager/Loaders/DotenvLoader.php
+++ b/src/EnvManager/Loaders/DotenvLoader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace UploadAbstractor\Support\Loaders;
+namespace EnvManager\Loaders;
 
 class DotenvLoader
 {

--- a/src/EnvManager/Readers/ArrayEnvReader.php
+++ b/src/EnvManager/Readers/ArrayEnvReader.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace UploadAbstractor\Support\Readers;
+namespace EnvManager\Readers;
 
-use UploadAbstractor\Support\Contracts\EnvironmentInterface;
+use EnvManager\Contracts\EnvironmentInterface;
 
 class ArrayEnvReader implements EnvironmentInterface
 {

--- a/src/EnvManager/Readers/GetenvReader.php
+++ b/src/EnvManager/Readers/GetenvReader.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace UploadAbstractor\Support\Readers;
+namespace EnvManager\Readers;
 
-use UploadAbstractor\Support\Contracts\EnvironmentInterface;
+use EnvManager\Contracts\EnvironmentInterface;
 
 class GetenvReader implements EnvironmentInterface
 {

--- a/src/EnvManager/Readers/ServerEnvReader.php
+++ b/src/EnvManager/Readers/ServerEnvReader.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace UploadAbstractor\Support\Readers;
+namespace EnvManager\Readers;
 
-use UploadAbstractor\Support\Contracts\EnvironmentInterface;
+use EnvManager\Contracts\EnvironmentInterface;
 
 class ServerEnvReader implements EnvironmentInterface
 {

--- a/src/UploadAbstractor/Drivers/LocalUpload.php
+++ b/src/UploadAbstractor/Drivers/LocalUpload.php
@@ -1,9 +1,9 @@
 <?php
 namespace UploadAbstractor\Drivers;
 
-use UploadAbstractor\Interfaces\UploadInterface;
+use UploadAbstractor\Interfaces\UploaderInterface;
 
-class LocalUpload implements UploadInterface
+class LocalUpload implements UploaderInterface
 {
     public function __construct(
         private readonly string $basePath = '/tmp/uploads'

--- a/src/UploadAbstractor/Drivers/S3Upload.php
+++ b/src/UploadAbstractor/Drivers/S3Upload.php
@@ -4,10 +4,10 @@ namespace UploadAbstractor\Drivers;
 
 use Aws\S3\S3Client;
 use Aws\Exception\AwsException;
-use UploadAbstractor\Interfaces\UploadInterface;
-use UploadAbstractor\Support\EnvManager;
+use UploadAbstractor\Interfaces\UploaderInterface;
+use EnvManager\EnvManager;
 
-class S3Upload implements UploadInterface
+class S3Upload implements UploaderInterface
 {
     private S3Client $client;
     private EnvManager $env;

--- a/src/UploadAbstractor/Enums/UploaderDriver.php
+++ b/src/UploadAbstractor/Enums/UploaderDriver.php
@@ -1,7 +1,7 @@
 <?php
 namespace UploadAbstractor\Enums;
 
-enum UploadDriver: string
+enum UploaderDriver: string
 {
     case S3 = 's3';
     case LOCAL = 'local';

--- a/src/UploadAbstractor/Interfaces/UploaderInterface.php
+++ b/src/UploadAbstractor/Interfaces/UploaderInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace UploadAbstractor\Interfaces;
 
-interface UploadInterface
+interface UploaderInterface
 {
     public function createRepository(string $name): bool;
     public function upload(string $bucket, string $key, string $filePath): ?string;

--- a/src/UploadAbstractor/UploaderFile.php
+++ b/src/UploadAbstractor/UploaderFile.php
@@ -1,27 +1,27 @@
 <?php
 namespace UploadAbstractor;
 
-use UploadAbstractor\Enums\UploadDriver;
-use UploadAbstractor\Interfaces\UploadInterface;
+use UploadAbstractor\Enums\UploaderDriver;
+use UploadAbstractor\Interfaces\UploaderInterface;
 use UploadAbstractor\Drivers\S3Upload;
 use UploadAbstractor\Drivers\LocalUpload;
-use UploadAbstractor\Support\EnvManager;
+use EnvManager\EnvManager;
 
-class UploadFile
+class UploaderFile
 {
-    private UploadInterface $driver;
+    private UploaderInterface $driver;
 
-    public function __construct(UploadDriver $option, ?EnvManager $env = null)
+    public function __construct(UploaderDriver $option, ?EnvManager $env = null)
     {
         $env ??= EnvManager::createWithDefaultReaders();
 
         $this->driver = match ($option) {
-            UploadDriver::S3 => new S3Upload($env),
-            UploadDriver::LOCAL => new LocalUpload(),
+            UploaderDriver::S3 => new S3Upload($env),
+            UploaderDriver::LOCAL => new LocalUpload(),
         };
     }
 
-    public function getDriver(): UploadInterface
+    public function getDriver(): UploaderInterface
     {
         return $this->driver;
     }

--- a/tests/Upload/S3UploadTest.php
+++ b/tests/Upload/S3UploadTest.php
@@ -1,15 +1,15 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use UploadAbstractor\UploadFile;
-use UploadAbstractor\Enums\UploadDriver;
-use UploadAbstractor\Support\EnvManager;
+use UploadAbstractor\UploaderFile;
+use UploadAbstractor\Enums\UploaderDriver;
+use EnvManager\EnvManager;
 class S3UploadTest extends TestCase
 {
     private string $bucket = 'php-unit-bucket';
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\S3Upload
      *
      * Tests that a new S3 bucket can be created successfully.
@@ -18,18 +18,18 @@ class S3UploadTest extends TestCase
      */
     public function testCanCreateS3Bucket()
     {
-        $upload = new UploadFile(UploadDriver::S3);
+        $upload = new UploaderFile(UploaderDriver::S3);
         $result = $upload->createRepository($this->bucket);
         $this->assertTrue($result);
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\S3Upload
      */
     public function testCanUploadToS3()
     {
-        $upload = new UploadFile(UploadDriver::S3);
+        $upload = new UploaderFile(UploaderDriver::S3);
         $upload->createRepository($this->bucket);
 
         $filePath = tempnam(sys_get_temp_dir(), 's3upl');
@@ -41,12 +41,12 @@ class S3UploadTest extends TestCase
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\S3Upload
      */
     public function testCanListS3Buckets()
     {
-        $upload = new UploadFile(UploadDriver::S3);
+        $upload = new UploaderFile(UploaderDriver::S3);
         $upload->createRepository($this->bucket);
 
         $buckets = $upload->listRepositories();
@@ -54,12 +54,12 @@ class S3UploadTest extends TestCase
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\S3Upload
      */
     public function testCanListS3Objects()
     {
-        $upload = new UploadFile(UploadDriver::S3);
+        $upload = new UploaderFile(UploaderDriver::S3);
         $upload->createRepository($this->bucket);
 
         $filePath = tempnam(sys_get_temp_dir(), 's3upl');

--- a/tests/Upload/UploadFileTest.php
+++ b/tests/Upload/UploadFileTest.php
@@ -1,29 +1,29 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use UploadAbstractor\UploadFile;
-use UploadAbstractor\Enums\UploadDriver;
+use UploadAbstractor\UploaderFile;
+use UploadAbstractor\Enums\UploaderDriver;
 
 class UploadFileTest extends TestCase
 {
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\LocalUpload
      */
     public function testCanCreateLocalRepository()
     {
-        $upload = new UploadFile(UploadDriver::LOCAL);
+        $upload = new UploaderFile(UploaderDriver::LOCAL);
         $result = $upload->createRepository('test-bucket');
         $this->assertTrue($result);
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      */
-    public function testCanUploadFileLocally()
+    public function testCanUploaderFileLocally()
     {
-        $upload = new UploadFile(UploadDriver::LOCAL);
+        $upload = new UploaderFile(UploaderDriver::LOCAL);
         $upload->createRepository('test-bucket');
 
         $tempFile = tempnam(sys_get_temp_dir(), 'upl');
@@ -34,12 +34,12 @@ class UploadFileTest extends TestCase
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\LocalUpload
      */
     public function testCanListLocalBuckets()
     {
-        $upload = new UploadFile(UploadDriver::LOCAL);
+        $upload = new UploaderFile(UploaderDriver::LOCAL);
         $upload->createRepository('bucket1');
         $upload->createRepository('bucket2');
 
@@ -49,12 +49,12 @@ class UploadFileTest extends TestCase
     }
 
     /**
-     * @covers UploadAbstractor\UploadFile
+     * @covers UploadAbstractor\UploaderFile
      * @covers UploadAbstractor\Drivers\LocalUpload
      */
     public function testCanListLocalObjects()
     {
-        $upload = new UploadFile(UploadDriver::LOCAL);
+        $upload = new UploaderFile(UploaderDriver::LOCAL);
         $upload->createRepository('test-bucket');
 
         $filePath = sys_get_temp_dir() . '/exemplo.txt';


### PR DESCRIPTION
refactor: rename Upload-related classes and restructure project layout

- Renamed UploadFile to UploaderFile
- Renamed UploadDriver to UploaderDriver
- Renamed UploadInterface to UploaderInterface
- Moved all code into UploadAbstractor namespace (formerly src/)
- Renamed EnvManager to EnvManagar
- Updated composer.json PSR-4 autoload mapping
- Adjusted all namespaces and references in test and source files

BREAKING CHANGE: All UploadAbstraction class names and namespaces have been renamed; previous references will no longer work without updates.
