### PR TITLE
fix(env): load .env dynamically based on current working directory (getcwd)

### DIFF
--- a/src/EnvManager/EnvManager.php
+++ b/src/EnvManager/EnvManager.php
@@ -37,7 +37,7 @@ class EnvManager
 
     public static function createWithDefaultReaders(): self
     {
-        $instance = new self(new DotenvLoader(), dirname(__DIR__, 2));
+        $instance = new self(new DotenvLoader(), getcwd());
         $instance->addReader(new ArrayEnvReader());
         $instance->addReader(new ServerEnvReader());
         $instance->addReader(new GetenvReader());


### PR DESCRIPTION
Using dirname(__DIR__, 2) would break .env loading when the package is installed via composer.
This change ensures the EnvManager always loads from the correct project root,
even when installed as a dependency.